### PR TITLE
Fix/toc preview text

### DIFF
--- a/client/src/components/CherryEditor/index.jsx
+++ b/client/src/components/CherryEditor/index.jsx
@@ -84,7 +84,7 @@ function CherryEditor({
   const handleCancel = () => {
     cancelModal.confirm({
       title: 'Quit Editing',
-      content: 'Your current progress will be lost. Are you sure?',
+      content: 'Are you sure? Don\'t worry, your current progress will be saved locally after quiting.',
       centered: true,
       okText: 'Keep Editing',
       cancelText: 'Quit',

--- a/client/src/hooks/useAxios.js
+++ b/client/src/hooks/useAxios.js
@@ -54,7 +54,7 @@ const useAxios = () => {
             // sign out the user if it's marked as inactive or removed
             // when its session has not expired
             logout();
-            antdMessage.error('Illegal user. signing out');
+            antdMessage.error('Illegal user. Signing out');
             navigate(routes.home);
           }
         }

--- a/client/src/pages/Create/index.jsx
+++ b/client/src/pages/Create/index.jsx
@@ -63,7 +63,7 @@ function Create() {
         buttonPropsList={buttonPropsList}
         localStorageKey={localStorageKey}
       />
-      <FeedbackModal onSuccess={() => navigate(routes.home)} />
+      <FeedbackModal onSuccess={() => navigate(routes.blogs)} />
     </>
   );
 }

--- a/client/src/pages/Edit/index.jsx
+++ b/client/src/pages/Edit/index.jsx
@@ -112,7 +112,7 @@ function Edit() {
           localStorageKey={localStorageKey}
           loadSourceConfirmed={loadSourceConfirmed}
         />
-        <FeedbackModal onSuccess={() => navigate(routes.home)} />
+        <FeedbackModal onSuccess={() => navigate(routes.blogs)} />
         {confirmLocalDraftModalContext}
       </>
   );

--- a/client/src/utils/mdUtil.js
+++ b/client/src/utils/mdUtil.js
@@ -2,9 +2,9 @@ export const extractMetaData = (html) => {
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
 
-  // Select the first <h1> and first <p> element
+  // Select the first <h1> and first <p> element that is not from toc
   const h1 = doc.querySelector('h1');
-  const p = doc.querySelector('p');
+  const p = doc.querySelector('p:not(.toc-title)');
   let title = null;
   let previewText = null;
 
@@ -15,6 +15,7 @@ export const extractMetaData = (html) => {
   let maxLength = 280;
   if (p) {
     const pHtml = p.innerHTML;
+    // Only retrieve the content before the first line break of the first <p> element for preview text
     const pText = pHtml.split('<br>')[0].trim();
     while (maxLength < pText.length && pText[maxLength] !== ' ') {
       maxLength++;


### PR DESCRIPTION
Fix the bug that toc was falsely parsed as the preview text.
Redirect to the user blog page instead of home page after creating and editing a blog. 